### PR TITLE
Service Deferred Benchmarking Improvements

### DIFF
--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -45,11 +45,10 @@ benchmarks! {
 	set_config_with_u32 {}: update_resume_threshold(RawOrigin::Root, 100)
 	set_config_with_weight {}: update_weight_restrict_decay(RawOrigin::Root, Weight::from_parts(3_000_000, 0))
 	service_deferred {
-		let m in 1..T::MaxDeferredMessages::get();
 		let b in 1..T::MaxBucketsProcessed::get();
 
-		let max_messages = m as usize;
 		let max_processed = b as u16;
+		let max_messages = T::MaxDeferredMessages::get() as usize;
 		let para_id = ParaId::from(999);
 
 		let xcm = construct_xcm::<T::RuntimeCall>();

--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -45,11 +45,13 @@ benchmarks! {
 	set_config_with_u32 {}: update_resume_threshold(RawOrigin::Root, 100)
 	set_config_with_weight {}: update_weight_restrict_decay(RawOrigin::Root, Weight::from_parts(3_000_000, 0))
 	service_deferred {
+		let m in 1..T::MaxDeferredMessages::get();
+
+		let max_messages = m as usize;
 		let para_id = ParaId::from(999);
 
 		let xcm = construct_xcm::<T::RuntimeCall>();
 
-		let max_messages = T::MaxDeferredMessages::get() as usize;
 		let relay_block = T::RelayChainBlockNumberProvider::current_block_number();
 		// We set `deferred_to` to the current relay block number to make sure that the messages are serviced.
 		let deferred_message = DeferredMessage { sent_at: relay_block, deferred_to: relay_block, sender: para_id, xcm };
@@ -80,6 +82,10 @@ benchmarks! {
 		assert!(Overweight::<T>::contains_key((max_processed as usize * max_messages - 1) as u64));
 	}
 	discard_deferred_bucket {
+		let m in 1..T::MaxDeferredMessages::get();
+
+		let max_messages = m as usize;
+
 		let para_id = ParaId::from(999);
 
 		let xcm = construct_xcm::<T::RuntimeCall>();
@@ -87,7 +93,6 @@ benchmarks! {
 
 		let sent_at = 1;
 		let deferred_to = 6;
-		let max_messages = T::MaxDeferredMessages::get() as usize;
 		let deferred_message = DeferredMessage { sent_at, deferred_to, sender: para_id, xcm };
 		let deferred_xcm_messages = vec![deferred_message.clone(); max_messages];
 		crate::Pallet::<T>::inject_deferred_messages(para_id, (deferred_to, 0), deferred_xcm_messages.try_into().unwrap());
@@ -98,6 +103,9 @@ benchmarks! {
 		assert_eq!(crate::Pallet::<T>::messages_deferred_to(para_id, (deferred_to, 0)).len(), 0);
 	}
 	discard_deferred_individual {
+		let m in 1..T::MaxDeferredMessages::get();
+
+		let max_messages = m as usize;
 		let para_id = ParaId::from(999);
 
 		let xcm = construct_xcm::<T::RuntimeCall>();
@@ -105,7 +113,6 @@ benchmarks! {
 
 		let sent_at = 1;
 		let deferred_to = 6;
-		let max_messages = T::MaxDeferredMessages::get() as usize;
 		let deferred_message = DeferredMessage { sent_at, deferred_to, sender: para_id, xcm };
 		let deferred_xcm_messages = vec![deferred_message.clone(); max_messages];
 		crate::Pallet::<T>::inject_deferred_messages(para_id, (deferred_to, 0), deferred_xcm_messages.try_into().unwrap());
@@ -118,11 +125,13 @@ benchmarks! {
 		assert_eq!(messages[max_messages - 1], None);
 	}
 	try_place_in_deferred_queue {
+		let m in 1..T::MaxDeferredMessages::get();
+
+		let max_messages = m as usize;
 		let para_id = ParaId::from(999);
 
 		let xcm = construct_xcm::<T::RuntimeCall>();
 
-		let max_messages = T::MaxDeferredMessages::get() as usize;
 		let relay_block = T::RelayChainBlockNumberProvider::current_block_number();
 		let max_buckets = T::MaxDeferredBuckets::get();
 		let indices: Vec<DeferredIndex> = (0..(max_buckets-1)).map(|i| (relay_block, i as u16)).collect();

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -439,7 +439,7 @@ pub mod pallet {
 		///
 		/// - `origin`: Must pass `ExecuteDeferredOrigin`.
 		/// - `weight_limit`: Maximum weight budget for deferred message execution.
-		/// - `para_id`: The queue to service.
+		/// - `para_id`: The parachain id where the deferred messages were sent from.
 		/// - `max_processed`: The maximum number of buckets to process.
 		#[pallet::call_index(15)]
 		#[pallet::weight((weight_limit.saturating_add(T::WeightInfo::service_deferred(*max_processed)), DispatchClass::Operational))]

--- a/cumulus/pallets/xcmp-queue/src/mock.rs
+++ b/cumulus/pallets/xcmp-queue/src/mock.rs
@@ -297,7 +297,17 @@ pub fn create_versioned_reserve_asset_deposited() -> VersionedXcm<RuntimeCall> {
 
 pub fn format_message(msg: &mut Vec<u8>, encoded_xcm: Vec<u8>) -> &[u8] {
 	msg.extend(XcmpMessageFormat::ConcatenatedVersionedXcm.encode());
-	msg.extend(encoded_xcm.clone());
+	msg.extend(encoded_xcm);
+	msg
+}
+
+pub fn format_messages<I>(msg: &mut Vec<u8>, encoded_xcms: I) -> &[u8] 
+where I:  IntoIterator<Item = Vec<u8>>
+{
+	msg.extend(XcmpMessageFormat::ConcatenatedVersionedXcm.encode());
+	for encoded_xcm in encoded_xcms.into_iter() {
+		msg.extend(encoded_xcm);
+	}
 	msg
 }
 

--- a/cumulus/pallets/xcmp-queue/src/mock.rs
+++ b/cumulus/pallets/xcmp-queue/src/mock.rs
@@ -239,6 +239,7 @@ impl XcmDeferFilter<RuntimeCall> for XcmDeferFilterMock {
 parameter_types! {
 	pub const MaxDeferredMessages: u32 = 20;
 	pub const MaxDeferredBuckets: u32 = 10;
+	pub const MaxBucketsProcessed: u32 = 5;
 }
 
 impl Config for Test {
@@ -255,6 +256,7 @@ impl Config for Test {
 	type XcmDeferFilter = XcmDeferFilterMock;
 	type MaxDeferredMessages = MaxDeferredMessages;
 	type MaxDeferredBuckets = MaxDeferredBuckets;
+	type MaxBucketsProcessed = MaxBucketsProcessed;
 	type RelayChainBlockNumberProvider = RelayBlockNumberProviderMock;
 }
 

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -581,10 +581,9 @@ fn service_deferred_queues_should_pass_overweight_messages_to_overweight_queue()
 			MultiAssets::new(),
 		)]);
 		// We just set a very low max_inidividual_weight to trigger the overweight logic
-		let db_weights: RuntimeDbWeight = <Test as frame_system::Config>::DbWeight::get();
 		let low_max_individual_weight = Weight::from_parts(100, 1);
 		let low_max_weight =
-			low_max_individual_weight.saturating_add(db_weights.reads_writes(2, 2));
+			low_max_individual_weight.saturating_add(<Test as Config>::WeightInfo::service_deferred());
 		assert!(FixedWeigher::weight(&mut xcm).unwrap().any_gt(low_max_weight));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
@@ -625,10 +624,9 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 			MultiAssets::new(),
 		)]);
 		// We just set a very low max weight to stop processing deferred messages early
-		let db_weights: RuntimeDbWeight = <Test as frame_system::Config>::DbWeight::get();
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
-			.saturating_add(db_weights.reads_writes(2, 2));
+			.saturating_add(<Test as Config>::WeightInfo::service_deferred());
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let second_para_id = ParaId::from(1000);
@@ -684,10 +682,9 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 			MultiAssets::new(),
 		)]);
 		// We just set a very low max weight to stop processing deferred messages early
-		let db_weights: RuntimeDbWeight = <Test as frame_system::Config>::DbWeight::get();
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
-			.saturating_add(db_weights.reads_writes(2, 2));
+			.saturating_add(<Test as Config>::WeightInfo::service_deferred());
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let mut xcmp_message = Vec::new();

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -871,6 +871,8 @@ fn discard_deferred_should_remove_messages_when_only_required_params_specified()
 	});
 }
 
+// TODO: test for placing more than MaxMesssages into queue so we use more than one bucket
+
 #[test]
 fn handle_xcmp_messages_should_execute_deferred_message_from_different_blocks() {
 	new_test_ext().execute_with(|| {

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -583,7 +583,8 @@ fn service_deferred_queues_should_pass_overweight_messages_to_overweight_queue()
 		// We just set a very low max_inidividual_weight to trigger the overweight logic
 		let low_max_individual_weight = Weight::from_parts(100, 1);
 		let low_max_weight =
-			low_max_individual_weight.saturating_add(<Test as Config>::WeightInfo::service_deferred());
+			low_max_individual_weight.saturating_add(
+				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxDeferredMessages::get()));
 		assert!(FixedWeigher::weight(&mut xcm).unwrap().any_gt(low_max_weight));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
@@ -626,7 +627,8 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 		// We just set a very low max weight to stop processing deferred messages early
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
-			.saturating_add(<Test as Config>::WeightInfo::service_deferred());
+			.saturating_add(
+				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxDeferredMessages::get()));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let second_para_id = ParaId::from(1000);
@@ -684,7 +686,8 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 		// We just set a very low max weight to stop processing deferred messages early
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
-			.saturating_add(<Test as Config>::WeightInfo::service_deferred());
+			.saturating_add(
+				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxDeferredMessages::get()));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let mut xcmp_message = Vec::new();

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -584,10 +584,7 @@ fn service_deferred_queues_should_pass_overweight_messages_to_overweight_queue()
 		let low_max_individual_weight = Weight::from_parts(100, 1);
 		let low_max_weight =
 			low_max_individual_weight.saturating_add(
-				<Test as Config>::WeightInfo::service_deferred(
-					<Test as Config>::MaxDeferredMessages::get(),
-					<Test as Config>::MaxBucketsProcessed::get(),
-				));
+				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxBucketsProcessed::get()));
 		assert!(FixedWeigher::weight(&mut xcm).unwrap().any_gt(low_max_weight));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
@@ -631,10 +628,7 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
 			.saturating_add(
-				<Test as Config>::WeightInfo::service_deferred(
-					<Test as Config>::MaxDeferredMessages::get(),
-					<Test as Config>::MaxBucketsProcessed::get(),
-				));
+				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxBucketsProcessed::get()));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let second_para_id = ParaId::from(1000);
@@ -693,10 +687,7 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
 			.saturating_add(
-				<Test as Config>::WeightInfo::service_deferred(
-					<Test as Config>::MaxDeferredMessages::get(),
-					<Test as Config>::MaxBucketsProcessed::get(),
-				));
+				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxBucketsProcessed::get()));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let mut xcmp_message = Vec::new();

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -466,7 +466,7 @@ fn service_deferred_should_execute_deferred_messages() {
 		RelayBlockNumberProviderMock::set(7);
 
 		//Act
-		assert_ok!(XcmpQueue::service_deferred(RuntimeOrigin::root(), Weight::MAX, para_id));
+		assert_ok!(XcmpQueue::service_deferred(RuntimeOrigin::root(), Weight::MAX, para_id, <Test as Config>::MaxBucketsProcessed::get()));
 
 		//Assert
 		assert_eq!(create_bounded_btreeset([].into_iter()), DeferredIndices::<Test>::get(para_id));
@@ -531,7 +531,7 @@ fn service_deferred_should_store_unprocessed_messages() {
 		RelayBlockNumberProviderMock::set(7);
 
 		//Act
-		assert_ok!(XcmpQueue::service_deferred(RuntimeOrigin::root(), Weight::MAX, para_id));
+		assert_ok!(XcmpQueue::service_deferred(RuntimeOrigin::root(), Weight::MAX, para_id, <Test as Config>::MaxBucketsProcessed::get()));
 
 		//Assert
 		assert_deferred_messages!(para_id, (8, 0), vec![Some(msg_not_to_process)]);
@@ -566,7 +566,7 @@ fn service_deferred_should_fail_when_called_with_wrong_origin() {
 
 		//Act and assert
 		assert_noop!(
-			XcmpQueue::service_deferred(RuntimeOrigin::signed(100), Weight::MAX, para_id),
+			XcmpQueue::service_deferred(RuntimeOrigin::signed(100), Weight::MAX, para_id, <Test as Config>::MaxBucketsProcessed::get()),
 			BadOrigin
 		);
 	});
@@ -584,7 +584,10 @@ fn service_deferred_queues_should_pass_overweight_messages_to_overweight_queue()
 		let low_max_individual_weight = Weight::from_parts(100, 1);
 		let low_max_weight =
 			low_max_individual_weight.saturating_add(
-				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxDeferredMessages::get()));
+				<Test as Config>::WeightInfo::service_deferred(
+					<Test as Config>::MaxDeferredMessages::get(),
+					<Test as Config>::MaxBucketsProcessed::get(),
+				));
 		assert!(FixedWeigher::weight(&mut xcm).unwrap().any_gt(low_max_weight));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
@@ -628,7 +631,10 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
 			.saturating_add(
-				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxDeferredMessages::get()));
+				<Test as Config>::WeightInfo::service_deferred(
+					<Test as Config>::MaxDeferredMessages::get(),
+					<Test as Config>::MaxBucketsProcessed::get(),
+				));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let second_para_id = ParaId::from(1000);
@@ -687,7 +693,10 @@ fn service_deferred_queues_should_stop_processing_when_weight_limit_is_reached_f
 		let low_max_weight = FixedWeigher::weight(&mut xcm)
 			.unwrap()
 			.saturating_add(
-				<Test as Config>::WeightInfo::service_deferred(<Test as Config>::MaxDeferredMessages::get()));
+				<Test as Config>::WeightInfo::service_deferred(
+					<Test as Config>::MaxDeferredMessages::get(),
+					<Test as Config>::MaxBucketsProcessed::get(),
+				));
 		let versioned_xcm = VersionedXcm::from(xcm);
 		let para_id = ParaId::from(999);
 		let mut xcmp_message = Vec::new();

--- a/cumulus/pallets/xcmp-queue/src/weights.rs
+++ b/cumulus/pallets/xcmp-queue/src/weights.rs
@@ -26,7 +26,7 @@ use sp_std::marker::PhantomData;
 pub trait WeightInfo {
 	fn set_config_with_u32() -> Weight;
 	fn set_config_with_weight() -> Weight;
-	fn service_deferred(m: u32) -> Weight;
+	fn service_deferred(m: u32, b: u32) -> Weight;
 	fn discard_deferred_bucket(m: u32) -> Weight;
 	fn discard_deferred_individual(m: u32) -> Weight;
 	fn try_place_in_deferred_queue(m: u32) -> Weight;
@@ -65,7 +65,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Proof Skipped: XcmpQueue OverweightCount (max_values: Some(1), max_size: None, mode: Measured)
 	// Storage: XcmpQueue Overweight (r:100 w:100)
 	// Proof Skipped: XcmpQueue Overweight (max_values: None, max_size: None, mode: Measured)
-	fn service_deferred(m: u32) -> Weight {
+	fn service_deferred(m: u32, b: u32) -> Weight {
 		Weight::from_parts(221_105_465_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(107 as u64))
 			.saturating_add(T::DbWeight::get().writes(104 as u64))
@@ -126,7 +126,7 @@ impl WeightInfo for () {
 	// Proof Skipped: XcmpQueue OverweightCount (max_values: Some(1), max_size: None, mode: Measured)
 	// Storage: XcmpQueue Overweight (r:100 w:100)
 	// Proof Skipped: XcmpQueue Overweight (max_values: None, max_size: None, mode: Measured)
-	fn service_deferred(m: u32) -> Weight {
+	fn service_deferred(m: u32, b: u32) -> Weight {
 		Weight::from_parts(221_105_465_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(107 as u64))
 			.saturating_add(RocksDbWeight::get().writes(104 as u64))

--- a/cumulus/pallets/xcmp-queue/src/weights.rs
+++ b/cumulus/pallets/xcmp-queue/src/weights.rs
@@ -26,7 +26,7 @@ use sp_std::marker::PhantomData;
 pub trait WeightInfo {
 	fn set_config_with_u32() -> Weight;
 	fn set_config_with_weight() -> Weight;
-	fn service_deferred(m: u32, b: u32) -> Weight;
+	fn service_deferred(b: u32) -> Weight;
 	fn discard_deferred_bucket(m: u32) -> Weight;
 	fn discard_deferred_individual(m: u32) -> Weight;
 	fn try_place_in_deferred_queue(m: u32) -> Weight;
@@ -65,7 +65,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Proof Skipped: XcmpQueue OverweightCount (max_values: Some(1), max_size: None, mode: Measured)
 	// Storage: XcmpQueue Overweight (r:100 w:100)
 	// Proof Skipped: XcmpQueue Overweight (max_values: None, max_size: None, mode: Measured)
-	fn service_deferred(m: u32, b: u32) -> Weight {
+	fn service_deferred(b: u32) -> Weight {
 		Weight::from_parts(221_105_465_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(107 as u64))
 			.saturating_add(T::DbWeight::get().writes(104 as u64))
@@ -126,7 +126,7 @@ impl WeightInfo for () {
 	// Proof Skipped: XcmpQueue OverweightCount (max_values: Some(1), max_size: None, mode: Measured)
 	// Storage: XcmpQueue Overweight (r:100 w:100)
 	// Proof Skipped: XcmpQueue Overweight (max_values: None, max_size: None, mode: Measured)
-	fn service_deferred(m: u32, b: u32) -> Weight {
+	fn service_deferred(b: u32) -> Weight {
 		Weight::from_parts(221_105_465_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(107 as u64))
 			.saturating_add(RocksDbWeight::get().writes(104 as u64))

--- a/cumulus/pallets/xcmp-queue/src/weights.rs
+++ b/cumulus/pallets/xcmp-queue/src/weights.rs
@@ -26,10 +26,10 @@ use sp_std::marker::PhantomData;
 pub trait WeightInfo {
 	fn set_config_with_u32() -> Weight;
 	fn set_config_with_weight() -> Weight;
-	fn service_deferred() -> Weight;
-	fn discard_deferred_bucket() -> Weight;
-	fn discard_deferred_individual() -> Weight;
-	fn try_place_in_deferred_queue() -> Weight;
+	fn service_deferred(m: u32) -> Weight;
+	fn discard_deferred_bucket(m: u32) -> Weight;
+	fn discard_deferred_individual(m: u32) -> Weight;
+	fn try_place_in_deferred_queue(m: u32) -> Weight;
 }
 
 pub struct SubstrateWeight<T>(PhantomData<T>);
@@ -65,21 +65,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Proof Skipped: XcmpQueue OverweightCount (max_values: Some(1), max_size: None, mode: Measured)
 	// Storage: XcmpQueue Overweight (r:100 w:100)
 	// Proof Skipped: XcmpQueue Overweight (max_values: None, max_size: None, mode: Measured)
-	fn service_deferred() -> Weight {
+	fn service_deferred(m: u32) -> Weight {
 		Weight::from_parts(221_105_465_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(107 as u64))
 			.saturating_add(T::DbWeight::get().writes(104 as u64))
 	}
 	// Storage: XcmpQueue DeferredMessageBuckets (r:1 w:1)
 	// Proof Skipped: XcmpQueue DeferredMessageBuckets (max_values: None, max_size: None, mode: Measured)
-	fn discard_deferred_bucket() -> Weight {
+	fn discard_deferred_bucket(m: u32) -> Weight {
 		Weight::from_parts(149_864_999_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: XcmpQueue DeferredMessageBuckets (r:1 w:1)
 	// Proof Skipped: XcmpQueue DeferredMessageBuckets (max_values: None, max_size: None, mode: Measured)
-	fn discard_deferred_individual() -> Weight {
+	fn discard_deferred_individual(m: u32) -> Weight {
 		Weight::from_parts(161_216_156_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
@@ -88,7 +88,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Proof Skipped: XcmpQueue DeferredIndices (max_values: None, max_size: None, mode: Measured)
 	// Storage: XcmpQueue DeferredMessageBuckets (r:1 w:1)
 	// Proof Skipped: XcmpQueue DeferredMessageBuckets (max_values: None, max_size: None, mode: Measured)
-	fn try_place_in_deferred_queue() -> Weight {
+	fn try_place_in_deferred_queue(m: u32) -> Weight {
 		Weight::from_parts(510_298_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
@@ -126,21 +126,21 @@ impl WeightInfo for () {
 	// Proof Skipped: XcmpQueue OverweightCount (max_values: Some(1), max_size: None, mode: Measured)
 	// Storage: XcmpQueue Overweight (r:100 w:100)
 	// Proof Skipped: XcmpQueue Overweight (max_values: None, max_size: None, mode: Measured)
-	fn service_deferred() -> Weight {
+	fn service_deferred(m: u32) -> Weight {
 		Weight::from_parts(221_105_465_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(107 as u64))
 			.saturating_add(RocksDbWeight::get().writes(104 as u64))
 	}
 	// Storage: XcmpQueue DeferredMessageBuckets (r:1 w:1)
 	// Proof Skipped: XcmpQueue DeferredMessageBuckets (max_values: None, max_size: None, mode: Measured)
-	fn discard_deferred_bucket() -> Weight {
+	fn discard_deferred_bucket(m: u32) -> Weight {
 		Weight::from_parts(149_864_999_000 as u64, 0)
 				.saturating_add(RocksDbWeight::get().reads(1 as u64))
 				.saturating_add(RocksDbWeight::get().writes(1 as u64))
 		}
 	// Storage: XcmpQueue DeferredMessageBuckets (r:1 w:1)
 	// Proof Skipped: XcmpQueue DeferredMessageBuckets (max_values: None, max_size: None, mode: Measured)
-	fn discard_deferred_individual() -> Weight {
+	fn discard_deferred_individual(m: u32) -> Weight {
 		Weight::from_parts(161_216_156_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
@@ -149,7 +149,7 @@ impl WeightInfo for () {
 	// Proof Skipped: XcmpQueue DeferredIndices (max_values: None, max_size: None, mode: Measured)
 	// Storage: XcmpQueue DeferredMessageBuckets (r:1 w:1)
 	// Proof Skipped: XcmpQueue DeferredMessageBuckets (max_values: None, max_size: None, mode: Measured)
-	fn try_place_in_deferred_queue() -> Weight {
+	fn try_place_in_deferred_queue(m: u32) -> Weight {
 		Weight::from_parts(510_298_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))


### PR DESCRIPTION
We want to improve PoV tracking for deferred execution. This PR adjusts the `service_deferred` benchmarking and uses its weight to make sure we don't go overweight while processing.